### PR TITLE
Release docker image for arm64.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: ci
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+    tags:
+      - v*
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Prepare
+        id: prepare
+        run: |
+            TAG=${GITHUB_REF##*/}
+            echo ::set-output name=tag_name::${TAG}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login do docker.io
+        run: docker login -u logentries -p ${{ secrets.DOCKER_TOKEN }}
+      - name: build and publish image
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            logentries/docker-logentries:${{ steps.prepare.outputs.tag_name }}
+            logentries/docker-logentries:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 #
 # VERSION 0.2.0
 
-FROM node:0.12-onbuild
+FROM node:8.17.0-onbuild
 MAINTAINER Rapid 7 - InsightOps <InsightOpsTeam@rapid7.com>
 
 WORKDIR /usr/src/app


### PR DESCRIPTION

Hi

Package Owner: Abhishek Nishant

PR change Details:

Patch Details: Following files has been created :

.github/workflows/ci.yml: Added ci.yml file to build and push the image for both amd64 and arm64 platforms.
Dockerfile: Base image is updated from node:0.12-onbuild to node:lts-alpine3.14 as node:lts-alpine3.14 has arm64 support present in it.

PR Description: Here is my commit message :
Release docker image for arm64.

PR Description:

The following file has been created and modified:
Added .github/workflows/ci.yml file to build and push the image for both amd64 and arm64 platforms.
Dockerfile: Base image is updated from node:0.12-onbuild to node:lts-alpine3.14 as node:lts-alpine3.14 has arm64 support present in it.

Testing details:

**Commit Link -** https://github.com/odidev/docker-logentries/commit/1499b6900280f29cfb5d08894130865dbd4afcc3 

**Github action link -** https://github.com/odidev/docker-logentries/runs/3439579249?check_suite_focus=true 

**Docker Hub Link -** https://hub.docker.com/repository/registry-1.docker.io/odidev/docker-logentries/tags?page=1&ordering=last_updated 

Signed-off-by: odidev odidev@puresoftware.com

Reviewer: Pruthvi Teja Reddy
Thanks
Abhishek Nishant
